### PR TITLE
Update Ruby-Cheatsheet.md

### DIFF
--- a/Ruby-Cheatsheet.md
+++ b/Ruby-Cheatsheet.md
@@ -1,5 +1,5 @@
 [back to overwiev](/../..)  
-Looking for [Rails](../Ruby-on-Rails-Cheatsheet.md)?
+Looking for [Rails](../master/Ruby-on-Rails-Cheatsheet.md)?
 
 # Ruby Cheatsheet
 


### PR DESCRIPTION
There seems to be a typo for the path of the Ruby cheat sheets. It's missing a "master" directory path in the link.