### PR TITLE
Ruby Cheatsheet path typo

### DIFF
--- a/Ruby-Cheatsheet.md
+++ b/Ruby-Cheatsheet.md
@@ -1,5 +1,5 @@
 [back to overwiev](/../..)  
-Looking for [Rails](../Ruby-on-Rails-Cheatsheet.md)?
+Looking for [Rails](../master/Ruby-on-Rails-Cheatsheet.md)?
 
 # Ruby Cheatsheet
 

--- a/Ruby-on-Rails-Cheatsheet.md
+++ b/Ruby-on-Rails-Cheatsheet.md
@@ -1,4 +1,4 @@
-Looking for [Ruby](../Ruby-Cheatsheet.md)?
+Looking for [Ruby](../master/Ruby-Cheatsheet.md)?
 
 #Ruby on Rails Cheatsheet
 


### PR DESCRIPTION
There seems to be a typo for the path of the Ruby cheat sheets. It's missing a "master" directory path in the link. It includes an extra commit than from the past PR.