### PR TITLE
Fix inconsistent class name

### DIFF
--- a/Ruby-Cheatsheet.md
+++ b/Ruby-Cheatsheet.md
@@ -118,7 +118,7 @@ end
 _custom objects_
 
 ```Ruby
-class ClassName # class names are rather written in PascalCase (It is similar to camelcase, but the first letter is capitalized)
+class Person # class names are rather written in PascalCase (It is similar to camelcase, but the first letter is capitalized)
   @@count = 0
   attr_reader :name # make it readable
   attr_writer :name # make it writable


### PR DESCRIPTION
This class name is different with the class method at line 136. It causes a confusion for the beginner of the Ruby language. 